### PR TITLE
(maint) Maintain backwards compatibility

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -292,10 +292,10 @@ class Vanagon
 
       # Adds action to run during the preinstall phase of packaging
       #
+      # @param scripts [Array] the Bourne shell compatible scriptlet(s) to execute
       # @param pkg_state [Array] the state in which the scripts should execute. Can be
       #   one or multiple of 'install' and 'upgrade'.
-      # @param scripts [Array] the Bourne shell compatible scriptlet(s) to execute
-      def add_preinstall_action(pkg_state, scripts)
+      def add_preinstall_action(scripts, pkg_state = ['install', 'upgrade'])
         pkg_state = Array(pkg_state)
         scripts = Array(scripts)
 
@@ -307,10 +307,10 @@ class Vanagon
 
       # Adds action to run during the postinstall phase of packaging
       #
+      # @param scripts [Array] the Bourne shell compatible scriptlet(s) to execute
       # @param pkg_state [Array] the state in which the scripts should execute. Can be
       #   one or multiple of 'install' and 'upgrade'.
-      # @param scripts [Array] the Bourne shell compatible scriptlet(s) to execute
-      def add_postinstall_action(pkg_state, scripts)
+      def add_postinstall_action(scripts, pkg_state = ['install', 'upgrade'])
         pkg_state = Array(pkg_state)
         scripts = Array(scripts)
 
@@ -322,10 +322,10 @@ class Vanagon
 
       # Adds action to run during the preremoval phase of packaging
       #
+      # @param scripts [Array] the Bourne shell compatible scriptlet(s) to execute
       # @param pkg_state [Array] the state in which the scripts should execute. Can be
       #   one or multiple of 'removal' and 'upgrade'.
-      # @param scripts [Array] the Bourne shell compatible scriptlet(s) to execute
-      def add_preremove_action(pkg_state, scripts)
+      def add_preremove_action(scripts, pkg_state = ['removal', 'upgrade'])
         pkg_state = Array(pkg_state)
         scripts = Array(scripts)
 
@@ -337,10 +337,10 @@ class Vanagon
 
       # Adds action to run during the postremoval phase of packaging
       #
+      # @param scripts [Array] the Bourne shell compatible scriptlet(s) to execute
       # @param pkg_state [Array] the state in which the scripts should execute. Can be
       #   one or multiple of 'removal' and 'upgrade'.
-      # @param scripts [Array] the Bourne shell compatible scriptlet(s) to execute
-      def add_postremove_action(pkg_state, scripts)
+      def add_postremove_action(scripts, pkg_state = ['removal', 'upgrade'])
         pkg_state = Array(pkg_state)
         scripts = Array(scripts)
 

--- a/spec/lib/vanagon/component/dsl_spec.rb
+++ b/spec/lib/vanagon/component/dsl_spec.rb
@@ -198,9 +198,15 @@ end" }
   describe '#add_actions' do
     it 'adds the corect preinstall action to the component' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      comp.add_preinstall_action(['install', 'upgrade'], ['chkconfig --list', '/bin/true'])
-      comp.add_preinstall_action('install', 'echo "hello, world"')
-      expect(comp._component.preinstall_actions.count).to eq(2)
+      comp.add_preinstall_action(['chkconfig --list', '/bin/true'], ['install', 'upgrade'])
+      comp.add_preinstall_action('echo "hello, world"', 'install')
+      comp.add_preinstall_action('echo "defaults"')
+      comp.add_preinstall_action <<-HERE.undent
+              if [ $1 -gt 1 ]; then
+                echo 'heredoc'
+              fi
+            HERE
+      expect(comp._component.preinstall_actions.count).to eq(4)
       expect(comp._component.preinstall_actions.first.scripts.count).to eq(2)
       expect(comp._component.preinstall_actions.first.pkg_state.count).to eq(2)
       expect(comp._component.preinstall_actions.first.pkg_state.first).to eq('install')
@@ -208,27 +214,47 @@ end" }
       expect(comp._component.preinstall_actions.first.scripts.first).to eq('chkconfig --list')
       expect(comp._component.preinstall_actions.first.scripts.last).to eq('/bin/true')
 
+      expect(comp._component.preinstall_actions.fetch(1).scripts.count).to eq(1)
+      expect(comp._component.preinstall_actions.fetch(1).pkg_state.count).to eq(1)
+      expect(comp._component.preinstall_actions.fetch(1).pkg_state.first).to eq('install')
+      expect(comp._component.preinstall_actions.fetch(1).scripts.first).to eq('echo "hello, world"')
+
+      expect(comp._component.preinstall_actions.fetch(2).scripts.count).to eq(1)
+      expect(comp._component.preinstall_actions.fetch(2).pkg_state.count).to eq(2)
+      expect(comp._component.preinstall_actions.fetch(2).pkg_state.first).to eq('install')
+      expect(comp._component.preinstall_actions.fetch(2).pkg_state.last).to eq('upgrade')
+      expect(comp._component.preinstall_actions.fetch(2).scripts.first).to eq('echo "defaults"')
+
       expect(comp._component.preinstall_actions.last.scripts.count).to eq(1)
-      expect(comp._component.preinstall_actions.last.pkg_state.count).to eq(1)
+      expect(comp._component.preinstall_actions.last.pkg_state.count).to eq(2)
       expect(comp._component.preinstall_actions.last.pkg_state.first).to eq('install')
-      expect(comp._component.preinstall_actions.last.scripts.first).to eq('echo "hello, world"')
+      expect(comp._component.preinstall_actions.last.pkg_state.last).to eq('upgrade')
+      expect(comp._component.preinstall_actions.last.scripts.first).to eq("if [ $1 -gt 1 ]; then\n  echo 'heredoc'\nfi\n")
+
+
     end
 
     it 'fails with bad preinstall action' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      expect { comp.add_preinstall_action('foo', '/bin/true') }.to raise_error(Vanagon::Error)
+      expect { comp.add_preinstall_action('/bin/true', 'foo') }.to raise_error(Vanagon::Error)
     end
 
     it 'fails with empty preinstall action' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      expect { comp.add_preinstall_action([], '/bin/true') }.to raise_error(Vanagon::Error)
+      expect { comp.add_preinstall_action('/bin/true', []) }.to raise_error(Vanagon::Error)
     end
 
     it 'adds the corect postinstall action to the component' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      comp.add_postinstall_action(['install', 'upgrade'], ['chkconfig --list', '/bin/true'])
-      comp.add_postinstall_action('install', 'echo "hello, world"')
-      expect(comp._component.postinstall_actions.count).to eq(2)
+      comp.add_postinstall_action(['chkconfig --list', '/bin/true'], ['install', 'upgrade'])
+      comp.add_postinstall_action('echo "hello, world"', 'install')
+      comp.add_postinstall_action('echo "defaults"')
+      comp.add_postinstall_action <<-HERE.undent
+              if [ $1 -gt 1 ]; then
+                echo 'heredoc'
+              fi
+            HERE
+      expect(comp._component.postinstall_actions.count).to eq(4)
       expect(comp._component.postinstall_actions.first.scripts.count).to eq(2)
       expect(comp._component.postinstall_actions.first.pkg_state.count).to eq(2)
       expect(comp._component.postinstall_actions.first.pkg_state.first).to eq('install')
@@ -236,27 +262,46 @@ end" }
       expect(comp._component.postinstall_actions.first.scripts.first).to eq('chkconfig --list')
       expect(comp._component.postinstall_actions.first.scripts.last).to eq('/bin/true')
 
+      expect(comp._component.postinstall_actions.fetch(1).scripts.count).to eq(1)
+      expect(comp._component.postinstall_actions.fetch(1).pkg_state.count).to eq(1)
+      expect(comp._component.postinstall_actions.fetch(1).pkg_state.first).to eq('install')
+      expect(comp._component.postinstall_actions.fetch(1).scripts.first).to eq('echo "hello, world"')
+
+      expect(comp._component.postinstall_actions.fetch(2).scripts.count).to eq(1)
+      expect(comp._component.postinstall_actions.fetch(2).pkg_state.count).to eq(2)
+      expect(comp._component.postinstall_actions.fetch(2).pkg_state.first).to eq('install')
+      expect(comp._component.postinstall_actions.fetch(2).pkg_state.last).to eq('upgrade')
+      expect(comp._component.postinstall_actions.fetch(2).scripts.first).to eq('echo "defaults"')
+
       expect(comp._component.postinstall_actions.last.scripts.count).to eq(1)
-      expect(comp._component.postinstall_actions.last.pkg_state.count).to eq(1)
+      expect(comp._component.postinstall_actions.last.pkg_state.count).to eq(2)
       expect(comp._component.postinstall_actions.last.pkg_state.first).to eq('install')
-      expect(comp._component.postinstall_actions.last.scripts.first).to eq('echo "hello, world"')
+      expect(comp._component.postinstall_actions.last.pkg_state.last).to eq('upgrade')
+      expect(comp._component.postinstall_actions.last.scripts.first).to eq("if [ $1 -gt 1 ]; then\n  echo 'heredoc'\nfi\n")
+
     end
 
     it 'fails with bad postinstall action' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      expect { comp.add_postinstall_action('foo', '/bin/true') }.to raise_error(Vanagon::Error)
+      expect { comp.add_postinstall_action('/bin/true', 'foo') }.to raise_error(Vanagon::Error)
     end
 
     it 'fails with empty postinstall action' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      expect { comp.add_postinstall_action([], '/bin/true') }.to raise_error(Vanagon::Error)
+      expect { comp.add_postinstall_action('/bin/true', []) }.to raise_error(Vanagon::Error)
     end
 
     it 'adds the corect preremove action to the component' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      comp.add_preremove_action(['removal', 'upgrade'], ['chkconfig --list', '/bin/true'])
-      comp.add_preremove_action('removal', 'echo "hello, world"')
-      expect(comp._component.preremove_actions.count).to eq(2)
+      comp.add_preremove_action(['chkconfig --list', '/bin/true'], ['removal', 'upgrade'])
+      comp.add_preremove_action('echo "hello, world"', 'removal')
+      comp.add_preremove_action('echo "defaults"')
+      comp.add_preremove_action <<-HERE.undent
+              if [ $1 -gt 1 ]; then
+                echo 'heredoc'
+              fi
+            HERE
+      expect(comp._component.preremove_actions.count).to eq(4)
       expect(comp._component.preremove_actions.first.scripts.count).to eq(2)
       expect(comp._component.preremove_actions.first.pkg_state.count).to eq(2)
       expect(comp._component.preremove_actions.first.pkg_state.first).to eq('removal')
@@ -264,27 +309,47 @@ end" }
       expect(comp._component.preremove_actions.first.scripts.first).to eq('chkconfig --list')
       expect(comp._component.preremove_actions.first.scripts.last).to eq('/bin/true')
 
+      expect(comp._component.preremove_actions.fetch(1).scripts.count).to eq(1)
+      expect(comp._component.preremove_actions.fetch(1).pkg_state.count).to eq(1)
+      expect(comp._component.preremove_actions.fetch(1).pkg_state.first).to eq('removal')
+      expect(comp._component.preremove_actions.fetch(1).scripts.first).to eq('echo "hello, world"')
+
+      expect(comp._component.preremove_actions.fetch(2).scripts.count).to eq(1)
+      expect(comp._component.preremove_actions.fetch(2).pkg_state.count).to eq(2)
+      expect(comp._component.preremove_actions.fetch(2).pkg_state.first).to eq('removal')
+      expect(comp._component.preremove_actions.fetch(2).pkg_state.last).to eq('upgrade')
+      expect(comp._component.preremove_actions.fetch(2).scripts.first).to eq('echo "defaults"')
+
       expect(comp._component.preremove_actions.last.scripts.count).to eq(1)
-      expect(comp._component.preremove_actions.last.pkg_state.count).to eq(1)
+      expect(comp._component.preremove_actions.last.pkg_state.count).to eq(2)
       expect(comp._component.preremove_actions.last.pkg_state.first).to eq('removal')
-      expect(comp._component.preremove_actions.last.scripts.first).to eq('echo "hello, world"')
+      expect(comp._component.preremove_actions.last.pkg_state.last).to eq('upgrade')
+      expect(comp._component.preremove_actions.last.scripts.first).to eq("if [ $1 -gt 1 ]; then\n  echo 'heredoc'\nfi\n")
+
+
     end
 
     it 'fails with bad preremove action' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      expect { comp.add_preremove_action('foo', '/bin/true') }.to raise_error(Vanagon::Error)
+      expect { comp.add_preremove_action('/bin/true', 'foo') }.to raise_error(Vanagon::Error)
     end
 
     it 'fails with empty preremove action' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      expect { comp.add_preremove_action([], '/bin/true') }.to raise_error(Vanagon::Error)
+      expect { comp.add_preremove_action('/bin/true', []) }.to raise_error(Vanagon::Error)
     end
 
     it 'adds the corect postremove action to the component' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      comp.add_postremove_action(['removal', 'upgrade'], ['chkconfig --list', '/bin/true'])
-      comp.add_postremove_action('removal', 'echo "hello, world"')
-      expect(comp._component.postremove_actions.count).to eq(2)
+      comp.add_postremove_action(['chkconfig --list', '/bin/true'], ['removal', 'upgrade'])
+      comp.add_postremove_action('echo "hello, world"', 'removal')
+      comp.add_postremove_action('echo "defaults"')
+      comp.add_postremove_action <<-HERE.undent
+              if [ $1 -gt 1 ]; then
+                echo 'heredoc'
+              fi
+            HERE
+      expect(comp._component.postremove_actions.count).to eq(4)
       expect(comp._component.postremove_actions.first.scripts.count).to eq(2)
       expect(comp._component.postremove_actions.first.pkg_state.count).to eq(2)
       expect(comp._component.postremove_actions.first.pkg_state.first).to eq('removal')
@@ -292,20 +357,33 @@ end" }
       expect(comp._component.postremove_actions.first.scripts.first).to eq('chkconfig --list')
       expect(comp._component.postremove_actions.first.scripts.last).to eq('/bin/true')
 
+      expect(comp._component.postremove_actions.fetch(1).scripts.count).to eq(1)
+      expect(comp._component.postremove_actions.fetch(1).pkg_state.count).to eq(1)
+      expect(comp._component.postremove_actions.fetch(1).pkg_state.first).to eq('removal')
+      expect(comp._component.postremove_actions.fetch(1).scripts.first).to eq('echo "hello, world"')
+
+      expect(comp._component.postremove_actions.fetch(2).scripts.count).to eq(1)
+      expect(comp._component.postremove_actions.fetch(2).pkg_state.count).to eq(2)
+      expect(comp._component.postremove_actions.fetch(2).pkg_state.first).to eq('removal')
+      expect(comp._component.postremove_actions.fetch(2).pkg_state.last).to eq('upgrade')
+      expect(comp._component.postremove_actions.fetch(2).scripts.first).to eq('echo "defaults"')
+
       expect(comp._component.postremove_actions.last.scripts.count).to eq(1)
-      expect(comp._component.postremove_actions.last.pkg_state.count).to eq(1)
+      expect(comp._component.postremove_actions.last.pkg_state.count).to eq(2)
       expect(comp._component.postremove_actions.last.pkg_state.first).to eq('removal')
-      expect(comp._component.postremove_actions.last.scripts.first).to eq('echo "hello, world"')
+      expect(comp._component.postremove_actions.last.pkg_state.last).to eq('upgrade')
+      expect(comp._component.postremove_actions.last.scripts.first).to eq("if [ $1 -gt 1 ]; then\n  echo 'heredoc'\nfi\n")
+
     end
 
     it 'fails with bad postremove action' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      expect { comp.add_postremove_action('foo', '/bin/true') }.to raise_error(Vanagon::Error)
+      expect { comp.add_postremove_action('/bin/true', 'foo') }.to raise_error(Vanagon::Error)
     end
 
     it 'fails with empty postremove action' do
       comp = Vanagon::Component::DSL.new('action-test', {}, dummy_platform_sysv)
-      expect { comp.add_postremove_action([], '/bin/true') }.to raise_error(Vanagon::Error)
+      expect { comp.add_postremove_action('/bin/true', []) }.to raise_error(Vanagon::Error)
     end
   end
 


### PR DESCRIPTION
For all of the methods to add new actions, make the script the first
parameter and have pkg_state default to adding these actions for both
upgrade and install or removal. This makes the code backwards compatible
with the previous implementations of add_preinstall_action and
add_postinstall_action.
